### PR TITLE
#40:メモリ節約のためdjangoコンテナとceleryコンテナを統合

### DIFF
--- a/Docker/Django/Dockerfile
+++ b/Docker/Django/Dockerfile
@@ -1,21 +1,9 @@
 # uwsgiがpython3.9以下でしか使えず、whisperがpython3.8以上しか使えない様子のため、3.9に設定
-FROM nvidia/cuda:11.7.1-cudnn8-runtime-ubuntu20.04 
-RUN ln -sf /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
-RUN apt-get update && \
-    apt-get install -y python3-pip python3-dev default-libmysqlclient-dev build-essential && \
-    rm -rf /var/lib/apt/lists/*
-
+FROM python:3.9
 ENV PYTHONUNBUFFERED 1
 RUN mkdir /code
 RUN apt update
-RUN apt install -y ffmpeg
-# RUN apt install -y libcudnn8*
-RUN apt-get install -y locales
-RUN locale-gen ja_JP.UTF-8
-ENV LANG ja_JP.UTF-8
-ENV LANGUAGE ja_JP:ja
-ENV LC_ALL ja_JP.UTF-8
-
+RUN apt -y install libgl1-mesa-glx
 WORKDIR /code
 ADD requirements.txt /code/
 RUN pip install -r requirements.txt

--- a/Docker/Django/requirements.txt
+++ b/Docker/Django/requirements.txt
@@ -1,21 +1,25 @@
-Django<4
-uwsgi
+Django==3.2.23
+uWSGI==2.0.23
 mysqlclient == 2.1.0
 
-typing_extensions
-langchain
+# chatGPT関係
+typing-extensions==4.9.0
+langchain==0.0.352
 openai == 0.28.1
 
-celery
-django-celery-results
-django-redis
+# celery関係
+celery==5.3.6
+django-celery-results==2.5.1
+django-redis==5.4.0
 
-boto3
-django-storages
+# AWS関係 
+boto3==1.34.10
+django-storages==1.14.2
+sagemaker==2.203.0
 
-sagemaker
+# 要約のマークダウン編集関係
+django-mdeditor==0.1.20
+Markdown==3.5.1
 
-django-mdeditor
-Markdown
-
-opencv-python
+# サムネイル生成関係
+opencv-python==4.8.1.78

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,12 @@ version: "3.9"
 services:
   django:
     build: ./Docker/Django
-    command: bash -c "python3 manage.py migrate && python3 manage.py collectstatic --noinput && uwsgi --socket :8000 --module project.wsgi --py-autoreload 1 --logto /tmp/mylog.log"
+    command: >
+      bash -c "
+        python3 manage.py collectstatic --noinput
+        celery -A project worker -l info --concurrency=1 &
+        uwsgi --socket :8000 --module project.wsgi --py-autoreload 1 --logto /tmp/mylog.log
+        "
     volumes:
       - ./src:/code
       - ./static:/static
@@ -18,11 +23,6 @@ services:
       redis:
         # redisのヘルスチェックが終わってからappを起動させる
         condition: service_healthy
-    # deploy:
-    #   resources:
-    #     reservations:
-    #       devices:
-    #         - capabilities: [gpu]
 
   db:
     image: mysql:8.0
@@ -75,22 +75,15 @@ services:
       # ヘルスチェックが失敗しても無視する時間は30秒
       start_period: 30s
 
-  celery:
-    build: ./Docker/Django
-    tty: true
-    command: celery -A project worker -l info --concurrency=1
-    volumes:
-      - ./src:/code
-    # expose:
-    #   - "8000"
-    env_file:
-      - openai_api.env
-    depends_on:
-      - django
-      - redis
-  #   deploy:
-  #     resources:
-  #       reservations:
-  #         devices:
-  #           - capabilities: [gpu]
+  # celery:
+  #   build: ./Docker/Django
+  #   tty: true
+  #   command: celery -A project worker -l info --concurrency=1
+  #   volumes:
+  #     - ./src:/code
+  #   env_file:
+  #     - openai_api.env
+  #   depends_on:
+  #     - django
+  #     - redis
 

--- a/src/templates/main.html
+++ b/src/templates/main.html
@@ -60,6 +60,7 @@
 
     img {
       width: 100%;
+      height: 160px;
       border-radius: 10px 10px 0 0;
       margin-bottom: 5px;
     }

--- a/src/templates/video.html
+++ b/src/templates/video.html
@@ -71,7 +71,7 @@
       poster="{{ video.thumbnail_path }}"
     >動画は再生できません。</video>
     <div class="video-info">
-      <p>投稿日時：{{ video.created_at }}</p>
+      <p>投稿日時：{{ video.uploaded_at }}</p>
       <p>投稿者：{{ video.user.username }}</p>
     </div>
   </div>


### PR DESCRIPTION
- djangoとceleryでコンテナをわけていたが、メモリ節約のためdjangoコンテナにceleryを統合しました
- djangoではGPU用のイメージを使用していましたが、sagemakerの私用に伴いdjangoでGPUの使用は不要となったためGPU用のイメージではなく通常のPythonのイメージに変更しました。