### PR TITLE
#47:AWS_ACCESS_KEY_IDとAWS_SECRET_ACCESS_KEYを環境変数ではなくDjangoのsettings_local.pyで管理

### DIFF
--- a/src/chapter_app/urls.py
+++ b/src/chapter_app/urls.py
@@ -2,7 +2,6 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path('signup/', views.signup_view, name='signup'),
     path('', views.login_view, name='login'),
     path('logout/', views.logout_view, name='logout'),
     path('user/', views.user_view, name='user'),

--- a/src/chapter_app/views.py
+++ b/src/chapter_app/views.py
@@ -154,7 +154,13 @@ def download_transcripion_view(request, pk):
     video = get_object_or_404(Video, pk=pk)
     file_name = video.transcription_path
 
-    s3 = boto3.client('s3', config=Config(signature_version='s3v4'))
+    s3 = boto3.client(
+        's3', 
+        config=Config(signature_version='s3v4'),
+        aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
+        aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
+        region_name=settings.AWS_S3_REGION_NAME
+        )
     bucket_name = settings.AWS_STORAGE_BUCKET_NAME 
     
     # プリサインされたURLの生成


### PR DESCRIPTION
- settings_local.pyにAWS_ACCESS_KEY_IDとAWS_SECRET_ACCESS_KEYの項目を追加
- views.pyのdownload_transcripion_view関数でAWS_ACCESS_KEY_IDとAWS_SECRET_ACCESS_KEYをsettings_local.pyから取得するように変更